### PR TITLE
Fix Next.js 15 build errors - Update serverComponentsExternalPackages and ES module compatibility

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -28,15 +28,20 @@ const nextConfig = {
     ignoreDuringBuilds: false,
   },
 
+  // Updated for Next.js 15 - moved from experimental.serverComponentsExternalPackages
+  serverExternalPackages: ['styled-jsx'],
+
   experimental: {
     esmExternals: true,
-    serverComponentsExternalPackages: ['styled-jsx'], // Keep this only
+    // Removed serverComponentsExternalPackages - moved to serverExternalPackages above
   },
 
   webpack: (config, { buildId, dev, isServer, defaultLoaders, nextRuntime, webpack }) => {
+    // Fix for ES modules - use dynamic import or alternative approach
     config.resolve.alias = {
       ...config.resolve.alias,
-      'styled-jsx': require.resolve('styled-jsx'),
+      // Remove the require.resolve as it's not available in ES modules
+      // styled-jsx should be handled by serverExternalPackages instead
     };
 
     config.resolve.fallback = {
@@ -52,4 +57,3 @@ const nextConfig = {
 };
 
 export default nextConfig;
-


### PR DESCRIPTION
## Fix Next.js 15 Configuration Issues

This PR fixes the build errors related to Next.js 15 configuration:

### Issues Fixed:

1. **`serverComponentsExternalPackages` deprecation**: 
   - ⚠️ `experimental.serverComponentsExternalPackages` has been moved to `serverExternalPackages` in Next.js 15
   - Updated configuration to use the new property

2. **ES Module compatibility**:
   - ❌ `require` is not defined in ES modules (`.mjs` files)
   - Removed `require.resolve('styled-jsx')` from webpack config
   - The styled-jsx handling is now properly managed by `serverExternalPackages`

### Changes Made:

- ✅ Moved `serverComponentsExternalPackages: ['styled-jsx']` to `serverExternalPackages: ['styled-jsx']`
- ✅ Removed `experimental.serverComponentsExternalPackages` from experimental config
- ✅ Removed `require.resolve('styled-jsx')` from webpack alias configuration
- ✅ Added comments explaining the changes for future reference

### Testing:

After these changes, the build should complete successfully without the following errors:
- ⚠️ Unrecognized key(s) in object: 'serverComponentsExternalPackages' at "experimental"
- ❌ ReferenceError: require is not defined

The styled-jsx package will still be properly handled through the `serverExternalPackages` configuration, which is the correct approach for Next.js 15.